### PR TITLE
Fix Rapid Direct create and update card

### DIFF
--- a/src/Message/RapidDirectCreateCardRequest.php
+++ b/src/Message/RapidDirectCreateCardRequest.php
@@ -12,10 +12,6 @@ namespace Omnipay\Eway\Message;
  * Once submitted, a TokenCustomerID is provided which can be
  * used in future transactions instead of the card details.
  *
- * Note that since no transaction is processed, the transaction
- * status is returned as false when a token is created. This means that
- * isSuccessful() cannot be used to check for success.
- *
  * Example:
  *
  * <code>
@@ -49,7 +45,9 @@ namespace Omnipay\Eway\Message;
  *   ));
  *
  *   $response = $request->send();
- *   $cardReference = $response->getCardReference();
+ *   if ($response->isSuccessful()) {
+ *       $cardReference = $response->getCardReference();
+ *   }
  * </code>
  *
  * @link https://eway.io/api-v3/#direct-connection
@@ -72,5 +70,14 @@ class RapidDirectCreateCardRequest extends RapidDirectAbstractRequest
     protected function getEndpoint()
     {
         return $this->getEndpointBase().'/DirectPayment.json';
+    }
+
+    public function sendData($data)
+    {
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
+            ->setAuth($this->getApiKey(), $this->getPassword())
+            ->send();
+
+        return $this->response = new RapidDirectCreateCardResponse($this, $httpResponse->json());
     }
 }

--- a/src/Message/RapidDirectCreateCardResponse.php
+++ b/src/Message/RapidDirectCreateCardResponse.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * eWAY Rapid Direct Create Card Response
+ */
+ 
+namespace Omnipay\Eway\Message;
+
+/**
+ * eWAY Rapid Direct Create Card Response
+ * 
+ * This is the response class for Rapid Direct when creating 
+ * or updating a card
+ *
+ */
+class RapidDirectCreateCardResponse extends RapidResponse
+{
+    public function isSuccessful()
+    {
+        return $this->data['ResponseMessage'] == 'A2000';
+    }
+}

--- a/src/Message/RapidDirectUpdateCardRequest.php
+++ b/src/Message/RapidDirectUpdateCardRequest.php
@@ -14,10 +14,6 @@ namespace Omnipay\Eway\Message;
  * This requires the TokenCustomerID of the token being updated, handled
  * in OmniPay as the cardReference.
  *
- * Note that since no transaction is processed, the transaction
- * status is returned as false when a token is created. This means that
- * isSuccessful() cannot be used to check for success.
- *
  * Example:
  *
  * <code>
@@ -52,7 +48,9 @@ namespace Omnipay\Eway\Message;
  *   ));
  *
  *   $response = $request->send();
- *   $cardReference = $response->getCardReference();
+ *   if ($response->isSuccessful()) {
+ *       $cardReference = $response->getCardReference();
+ *   }
  * </code>
  *
  * @link https://eway.io/api-v3/#direct-connection
@@ -79,5 +77,14 @@ class RapidDirectUpdateCardRequest extends RapidDirectAbstractRequest
     protected function getEndpoint()
     {
         return $this->getEndpointBase().'/DirectPayment.json';
+    }
+
+    public function sendData($data)
+    {
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
+            ->setAuth($this->getApiKey(), $this->getPassword())
+            ->send();
+
+        return $this->response = new RapidDirectCreateCardResponse($this, $httpResponse->json());
     }
 }

--- a/tests/Message/RapidDirectCreateCardRequestTest.php
+++ b/tests/Message/RapidDirectCreateCardRequestTest.php
@@ -75,7 +75,7 @@ class RapidDirectCreateCardRequestTest extends TestCase
         $this->setMockHttpResponse('RapidDirectCreateCardRequestSuccess.txt');
         $response = $this->request->send();
 
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertSame(916260137222, $response->getCardReference());
         $this->assertSame('Transaction Approved', $response->getMessage());
     }

--- a/tests/Message/RapidDirectUpdateCardRequestTest.php
+++ b/tests/Message/RapidDirectUpdateCardRequestTest.php
@@ -65,7 +65,7 @@ class RapidDirectUpdateCardRequestTest extends TestCase
         $this->setMockHttpResponse('RapidDirectUpdateCardRequestSuccess.txt');
         $response = $this->request->send();
 
-        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isSuccessful());
         $this->assertSame(917758625852, $response->getCardReference());
         $this->assertSame('Transaction Approved', $response->getMessage());
     }


### PR DESCRIPTION
Makes isSuccessful() return true instead of false when a card is created or updated with the Rapid Direct gateway. Includes updates to tests and doco in headers.

This resolves #13