### PR TITLE
Shared token requests

### DIFF
--- a/src/Message/RapidSharedCreateCardRequest.php
+++ b/src/Message/RapidSharedCreateCardRequest.php
@@ -12,7 +12,7 @@ namespace Omnipay\Eway\Message;
  *
  * @link https://eway.io/api-v3/#responsive-shared-page
  */
-class RapidSharedCreateCardRequest extends AbstractRequest
+class RapidSharedCreateCardRequest extends RapidSharedPurchaseRequest
 {
     public function getData()
     {
@@ -35,99 +35,5 @@ class RapidSharedCreateCardRequest extends AbstractRequest
         $data['Payment']['TotalAmount'] = 0;
 
         return $data;
-    }
-
-    public function sendData($data)
-    {
-        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
-            ->setAuth($this->getApiKey(), $this->getPassword())
-            ->send();
-
-        return $this->response = new RapidSharedResponse($this, $httpResponse->json());
-    }
-
-    protected function getEndpoint()
-    {
-        return $this->getEndpointBase().'/CreateAccessCodeShared.json';
-    }
-
-    public function getCancelUrl()
-    {
-        return $this->getParameter('cancelUrl');
-    }
-
-    public function setCancelUrl($value)
-    {
-        return $this->setParameter('cancelUrl', $value);
-    }
-
-    public function getLogoUrl()
-    {
-        return $this->getParameter('logoUrl');
-    }
-
-    public function setLogoUrl($value)
-    {
-        return $this->setParameter('logoUrl', $value);
-    }
-
-    public function getHeaderText()
-    {
-        return $this->getParameter('headerText');
-    }
-
-    public function setHeaderText($value)
-    {
-        return $this->setParameter('headerText', $value);
-    }
-
-    public function getLanguage()
-    {
-        return $this->getParameter('language');
-    }
-
-    public function setLanguage($value)
-    {
-        return $this->setParameter('language', $value);
-    }
-
-    public function getCustomerReadOnly()
-    {
-        return $this->getParameter('customerReadOnly');
-    }
-
-    public function setCustomerReadOnly($value)
-    {
-        return $this->setParameter('customerReadOnly', $value);
-    }
-
-    public function getCustomView()
-    {
-        return $this->getParameter('customView');
-    }
-
-    public function setCustomView($value)
-    {
-        return $this->setParameter('customView', $value);
-    }
-
-    public function getVerifyCustomerPhone()
-    {
-        return $this->getParameter('verifyCustomerPhone');
-    }
-
-    public function setVerifyCustomerPhone($value)
-    {
-        return $this->setParameter('verifyCustomerPhone', $value);
-    }
-
-    public function getVerifyCustomerEmail()
-    {
-        return $this->getParameter('verifyCustomerEmail');
-    }
-
-    public function setVerifyCustomerEmail($value)
-    {
-        return $this->setParameter('verifyCustomerEmail', $value);
     }
 }

--- a/src/Message/RapidSharedCreateCardRequest.php
+++ b/src/Message/RapidSharedCreateCardRequest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * eWAY Rapid Shared Page Create Card Request
+ */
+
+namespace Omnipay\Eway\Message;
+
+/**
+ * eWAY Rapid Shared Page Create Card Request
+ *
+ * Creates a payment URL using eWAY's Responsive Shared Page
+ *
+ * @link https://eway.io/api-v3/#responsive-shared-page
+ */
+class RapidSharedCreateCardRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('returnUrl');
+
+        $data = $this->getBaseData();
+        $data['Method'] = 'CreateTokenCustomer';
+        $data['TransactionType'] = 'Purchase';
+        $data['RedirectUrl'] = $this->getReturnUrl();
+
+        // Shared page parameters (optional)
+        $data['CancelUrl'] = $this->getCancelUrl();
+        $data['LogoUrl'] = $this->getLogoUrl();
+        $data['HeaderText'] = $this->getHeaderText();
+        $data['Language'] = $this->getLanguage();
+        $data['CustomerReadOnly'] = $this->getCustomerReadOnly();
+        $data['CustomView'] = $this->getCustomView();
+
+        $data['Payment'] = array();
+        $data['Payment']['TotalAmount'] = 0;
+
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
+            ->setAuth($this->getApiKey(), $this->getPassword())
+            ->send();
+
+        return $this->response = new RapidSharedResponse($this, $httpResponse->json());
+    }
+
+    protected function getEndpoint()
+    {
+        return $this->getEndpointBase().'/CreateAccessCodeShared.json';
+    }
+
+    public function getCancelUrl()
+    {
+        return $this->getParameter('cancelUrl');
+    }
+
+    public function setCancelUrl($value)
+    {
+        return $this->setParameter('cancelUrl', $value);
+    }
+
+    public function getLogoUrl()
+    {
+        return $this->getParameter('logoUrl');
+    }
+
+    public function setLogoUrl($value)
+    {
+        return $this->setParameter('logoUrl', $value);
+    }
+
+    public function getHeaderText()
+    {
+        return $this->getParameter('headerText');
+    }
+
+    public function setHeaderText($value)
+    {
+        return $this->setParameter('headerText', $value);
+    }
+
+    public function getLanguage()
+    {
+        return $this->getParameter('language');
+    }
+
+    public function setLanguage($value)
+    {
+        return $this->setParameter('language', $value);
+    }
+
+    public function getCustomerReadOnly()
+    {
+        return $this->getParameter('customerReadOnly');
+    }
+
+    public function setCustomerReadOnly($value)
+    {
+        return $this->setParameter('customerReadOnly', $value);
+    }
+
+    public function getCustomView()
+    {
+        return $this->getParameter('customView');
+    }
+
+    public function setCustomView($value)
+    {
+        return $this->setParameter('customView', $value);
+    }
+
+    public function getVerifyCustomerPhone()
+    {
+        return $this->getParameter('verifyCustomerPhone');
+    }
+
+    public function setVerifyCustomerPhone($value)
+    {
+        return $this->setParameter('verifyCustomerPhone', $value);
+    }
+
+    public function getVerifyCustomerEmail()
+    {
+        return $this->getParameter('verifyCustomerEmail');
+    }
+
+    public function setVerifyCustomerEmail($value)
+    {
+        return $this->setParameter('verifyCustomerEmail', $value);
+    }
+}

--- a/src/Message/RapidSharedUpdateCardRequest.php
+++ b/src/Message/RapidSharedUpdateCardRequest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * eWAY Rapid Shared Page Update Card Request
+ */
+
+namespace Omnipay\Eway\Message;
+
+/**
+ * eWAY Rapid Shared Page Update Card Request
+ *
+ * Creates a payment URL using eWAY's Responsive Shared Page
+ *
+ * @link https://eway.io/api-v3/#responsive-shared-page
+ */
+class RapidSharedUpdateCardRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('returnUrl');
+
+        $data = $this->getBaseData();
+        $data['Method'] = 'CreateTokenCustomer';
+        $data['TransactionType'] = 'Purchase';
+        $data['RedirectUrl'] = $this->getReturnUrl();
+
+        // Shared page parameters (optional)
+        $data['CancelUrl'] = $this->getCancelUrl();
+        $data['LogoUrl'] = $this->getLogoUrl();
+        $data['HeaderText'] = $this->getHeaderText();
+        $data['Language'] = $this->getLanguage();
+        $data['CustomerReadOnly'] = $this->getCustomerReadOnly();
+        $data['CustomView'] = $this->getCustomView();
+
+        $data['Payment'] = array();
+        $data['Payment']['TotalAmount'] = 0;
+
+        $data['Customer'] = array();
+        $data['Customer']['TokenCustomerID'] = $this->getTokenCustomerId();
+
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
+            ->setAuth($this->getApiKey(), $this->getPassword())
+            ->send();
+
+        return $this->response = new RapidSharedResponse($this, $httpResponse->json());
+    }
+
+    protected function getEndpoint()
+    {
+        return $this->getEndpointBase().'/CreateAccessCodeShared.json';
+    }
+
+    public function getCancelUrl()
+    {
+        return $this->getParameter('cancelUrl');
+    }
+
+    public function setCancelUrl($value)
+    {
+        return $this->setParameter('cancelUrl', $value);
+    }
+
+    public function getLogoUrl()
+    {
+        return $this->getParameter('logoUrl');
+    }
+
+    public function setLogoUrl($value)
+    {
+        return $this->setParameter('logoUrl', $value);
+    }
+
+    public function getHeaderText()
+    {
+        return $this->getParameter('headerText');
+    }
+
+    public function setHeaderText($value)
+    {
+        return $this->setParameter('headerText', $value);
+    }
+
+    public function getLanguage()
+    {
+        return $this->getParameter('language');
+    }
+
+    public function setLanguage($value)
+    {
+        return $this->setParameter('language', $value);
+    }
+
+    public function getCustomerReadOnly()
+    {
+        return $this->getParameter('customerReadOnly');
+    }
+
+    public function setCustomerReadOnly($value)
+    {
+        return $this->setParameter('customerReadOnly', $value);
+    }
+
+    public function getCustomView()
+    {
+        return $this->getParameter('customView');
+    }
+
+    public function setCustomView($value)
+    {
+        return $this->setParameter('customView', $value);
+    }
+
+    public function getVerifyCustomerPhone()
+    {
+        return $this->getParameter('verifyCustomerPhone');
+    }
+
+    public function setVerifyCustomerPhone($value)
+    {
+        return $this->setParameter('verifyCustomerPhone', $value);
+    }
+
+    public function getVerifyCustomerEmail()
+    {
+        return $this->getParameter('verifyCustomerEmail');
+    }
+
+    public function setVerifyCustomerEmail($value)
+    {
+        return $this->setParameter('verifyCustomerEmail', $value);
+    }
+
+    public function getTokenCustomerId()
+    {
+        return $this->getParameter('tokenCustomerId');
+    }
+
+    public function setTokenCustomerId($value)
+    {
+        return $this->setParameter('tokenCustomerId', $value);
+    }
+}

--- a/src/Message/RapidSharedUpdateCardRequest.php
+++ b/src/Message/RapidSharedUpdateCardRequest.php
@@ -12,7 +12,7 @@ namespace Omnipay\Eway\Message;
  *
  * @link https://eway.io/api-v3/#responsive-shared-page
  */
-class RapidSharedUpdateCardRequest extends AbstractRequest
+class RapidSharedUpdateCardRequest extends RapidSharedPurchaseRequest
 {
     public function getData()
     {
@@ -37,99 +37,5 @@ class RapidSharedUpdateCardRequest extends AbstractRequest
         $data['Customer']['TokenCustomerID'] = $this->getCardReference();
 
         return $data;
-    }
-
-    public function sendData($data)
-    {
-        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, json_encode($data))
-            ->setAuth($this->getApiKey(), $this->getPassword())
-            ->send();
-
-        return $this->response = new RapidSharedResponse($this, $httpResponse->json());
-    }
-
-    protected function getEndpoint()
-    {
-        return $this->getEndpointBase().'/CreateAccessCodeShared.json';
-    }
-
-    public function getCancelUrl()
-    {
-        return $this->getParameter('cancelUrl');
-    }
-
-    public function setCancelUrl($value)
-    {
-        return $this->setParameter('cancelUrl', $value);
-    }
-
-    public function getLogoUrl()
-    {
-        return $this->getParameter('logoUrl');
-    }
-
-    public function setLogoUrl($value)
-    {
-        return $this->setParameter('logoUrl', $value);
-    }
-
-    public function getHeaderText()
-    {
-        return $this->getParameter('headerText');
-    }
-
-    public function setHeaderText($value)
-    {
-        return $this->setParameter('headerText', $value);
-    }
-
-    public function getLanguage()
-    {
-        return $this->getParameter('language');
-    }
-
-    public function setLanguage($value)
-    {
-        return $this->setParameter('language', $value);
-    }
-
-    public function getCustomerReadOnly()
-    {
-        return $this->getParameter('customerReadOnly');
-    }
-
-    public function setCustomerReadOnly($value)
-    {
-        return $this->setParameter('customerReadOnly', $value);
-    }
-
-    public function getCustomView()
-    {
-        return $this->getParameter('customView');
-    }
-
-    public function setCustomView($value)
-    {
-        return $this->setParameter('customView', $value);
-    }
-
-    public function getVerifyCustomerPhone()
-    {
-        return $this->getParameter('verifyCustomerPhone');
-    }
-
-    public function setVerifyCustomerPhone($value)
-    {
-        return $this->setParameter('verifyCustomerPhone', $value);
-    }
-
-    public function getVerifyCustomerEmail()
-    {
-        return $this->getParameter('verifyCustomerEmail');
-    }
-
-    public function setVerifyCustomerEmail($value)
-    {
-        return $this->setParameter('verifyCustomerEmail', $value);
     }
 }

--- a/src/Message/RapidSharedUpdateCardRequest.php
+++ b/src/Message/RapidSharedUpdateCardRequest.php
@@ -16,10 +16,10 @@ class RapidSharedUpdateCardRequest extends AbstractRequest
 {
     public function getData()
     {
-        $this->validate('returnUrl');
+        $this->validate('returnUrl', 'cardReference');
 
         $data = $this->getBaseData();
-        $data['Method'] = 'CreateTokenCustomer';
+        $data['Method'] = 'UpdateTokenCustomer';
         $data['TransactionType'] = 'Purchase';
         $data['RedirectUrl'] = $this->getReturnUrl();
 
@@ -34,8 +34,7 @@ class RapidSharedUpdateCardRequest extends AbstractRequest
         $data['Payment'] = array();
         $data['Payment']['TotalAmount'] = 0;
 
-        $data['Customer'] = array();
-        $data['Customer']['TokenCustomerID'] = $this->getTokenCustomerId();
+        $data['Customer']['TokenCustomerID'] = $this->getCardReference();
 
         return $data;
     }
@@ -132,15 +131,5 @@ class RapidSharedUpdateCardRequest extends AbstractRequest
     public function setVerifyCustomerEmail($value)
     {
         return $this->setParameter('verifyCustomerEmail', $value);
-    }
-
-    public function getTokenCustomerId()
-    {
-        return $this->getParameter('tokenCustomerId');
-    }
-
-    public function setTokenCustomerId($value)
-    {
-        return $this->setParameter('tokenCustomerId', $value);
     }
 }

--- a/src/RapidSharedGateway.php
+++ b/src/RapidSharedGateway.php
@@ -73,4 +73,14 @@ class RapidSharedGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Eway\Message\RefundRequest', $parameters);
     }
+
+    public function createCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Eway\Message\RapidSharedCreateCardRequest', $parameters);
+    }
+
+    public function updateCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Eway\Message\RapidSharedUpdateCardRequest', $parameters);
+    }
 }

--- a/tests/Message/RapidSharedCreateCardRequestTest.php
+++ b/tests/Message/RapidSharedCreateCardRequestTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Omnipay\Eway\Message;
+
+use Omnipay\Tests\TestCase;
+
+class RapidSharedCreateCardRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new RapidSharedCreateCardRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(array(
+            'apiKey' => 'my api key',
+            'password' => 'secret',
+            'returnUrl' => 'https://www.example.com/return',
+        ));
+    }
+
+    public function testGetData()
+    {
+        $this->request->initialize(array(
+            'apiKey' => 'my api key',
+            'password' => 'secret',
+            'returnUrl' => 'https://www.example.com/return',
+            'card' => array(
+                'title' => 'Mr',
+                'firstName' => 'Patrick',
+                'lastName' => 'Collison',
+                'country' => 'AU',
+            ),
+        ));
+
+        $data = $this->request->getData();
+
+        $this->assertSame('Purchase', $data['TransactionType']);
+        $this->assertSame('CreateTokenCustomer', $data['Method']);
+        $this->assertSame('https://www.example.com/return', $data['RedirectUrl']);
+        $this->assertSame(0, $data['Payment']['TotalAmount']);
+        $this->assertSame('Mr', $data['Customer']['Title']);
+        $this->assertSame('Patrick', $data['Customer']['FirstName']);
+        $this->assertSame('Collison', $data['Customer']['LastName']);
+        $this->assertSame('au', $data['ShippingAddress']['Country']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('RapidSharedCreateCardRequestSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('GET', $response->getRedirectMethod());
+        $this->assertSame('https://secure.ewaypayments.com/sharedpayment?AccessCode=F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL', $response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+        $this->assertNull($response->getCode());
+        $this->assertNotNull($response->getCardReference());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('RapidSharedCreateCardRequestFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('V6042,V6043,V6044', $response->getCode());
+    }
+
+    public function testCancelUrl()
+    {
+        $this->assertSame($this->request, $this->request->setCancelUrl('http://www.example.com'));
+        $this->assertSame('http://www.example.com', $this->request->getCancelUrl());
+    }
+
+    public function testLogoUrl()
+    {
+        $this->assertSame($this->request, $this->request->setLogoUrl('https://www.example.com/logo.jpg'));
+        $this->assertSame('https://www.example.com/logo.jpg', $this->request->getLogoUrl());
+    }
+
+    public function testHeaderText()
+    {
+        $this->assertSame($this->request, $this->request->setHeaderText('Header Text'));
+        $this->assertSame('Header Text', $this->request->getHeaderText());
+    }
+
+    public function testLanguage()
+    {
+        $this->assertSame($this->request, $this->request->setLanguage('EN'));
+        $this->assertSame('EN', $this->request->getLanguage());
+    }
+
+    public function testCustomerReadOnly()
+    {
+        $this->assertSame($this->request, $this->request->setCustomerReadOnly('true'));
+        $this->assertSame('true', $this->request->getCustomerReadOnly());
+    }
+
+    public function testCustomView()
+    {
+        $this->assertSame($this->request, $this->request->setCustomView('Bootstrap'));
+        $this->assertSame('Bootstrap', $this->request->getCustomView());
+    }
+
+    public function testVerifyCustomerPhone()
+    {
+        $this->assertSame($this->request, $this->request->setVerifyCustomerPhone('true'));
+        $this->assertSame('true', $this->request->getVerifyCustomerPhone());
+    }
+
+    public function testVerifyCustomerEmail()
+    {
+        $this->assertSame($this->request, $this->request->setVerifyCustomerEmail('true'));
+        $this->assertSame('true', $this->request->getVerifyCustomerEmail());
+    }
+
+}

--- a/tests/Message/RapidSharedUpdateCardRequestTest.php
+++ b/tests/Message/RapidSharedUpdateCardRequestTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Omnipay\Eway\Message;
+
+use Omnipay\Tests\TestCase;
+
+class RapidSharedUpdateCardRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new RapidSharedUpdateCardRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(array(
+            'apiKey' => 'my api key',
+            'password' => 'secret',
+            'returnUrl' => 'https://www.example.com/return',
+            'cardReference' => '123456789'
+        ));
+    }
+
+    public function testGetData()
+    {
+        $this->request->initialize(array(
+            'apiKey' => 'my api key',
+            'password' => 'secret',
+            'returnUrl' => 'https://www.example.com/return',
+            'cardReference' => '123456789',
+            'card' => array(
+                'title' => 'Mr',
+                'firstName' => 'Patrick',
+                'lastName' => 'Collison',
+                'country' => 'AU',
+            ),
+        ));
+
+        $data = $this->request->getData();
+
+        $this->assertSame('Purchase', $data['TransactionType']);
+        $this->assertSame('UpdateTokenCustomer', $data['Method']);
+        $this->assertSame('https://www.example.com/return', $data['RedirectUrl']);
+        $this->assertSame(0, $data['Payment']['TotalAmount']);
+        $this->assertSame('Mr', $data['Customer']['Title']);
+        $this->assertSame('Patrick', $data['Customer']['FirstName']);
+        $this->assertSame('Collison', $data['Customer']['LastName']);
+        $this->assertSame('au', $data['ShippingAddress']['Country']);
+        $this->assertSame('123456789', $data['Customer']['TokenCustomerID']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('RapidSharedUpdateCardRequestSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertSame('GET', $response->getRedirectMethod());
+        $this->assertSame('https://secure.ewaypayments.com/sharedpayment?AccessCode=F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL', $response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+        $this->assertNull($response->getCode());
+        $this->assertNotNull($response->getCardReference());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('RapidSharedUpdateCardRequestFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getRedirectUrl());
+        $this->assertNull($response->getRedirectData());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('V6040', $response->getCode());
+    }
+
+    public function testCancelUrl()
+    {
+        $this->assertSame($this->request, $this->request->setCancelUrl('http://www.example.com'));
+        $this->assertSame('http://www.example.com', $this->request->getCancelUrl());
+    }
+
+    public function testLogoUrl()
+    {
+        $this->assertSame($this->request, $this->request->setLogoUrl('https://www.example.com/logo.jpg'));
+        $this->assertSame('https://www.example.com/logo.jpg', $this->request->getLogoUrl());
+    }
+
+    public function testHeaderText()
+    {
+        $this->assertSame($this->request, $this->request->setHeaderText('Header Text'));
+        $this->assertSame('Header Text', $this->request->getHeaderText());
+    }
+
+    public function testLanguage()
+    {
+        $this->assertSame($this->request, $this->request->setLanguage('EN'));
+        $this->assertSame('EN', $this->request->getLanguage());
+    }
+
+    public function testCustomerReadOnly()
+    {
+        $this->assertSame($this->request, $this->request->setCustomerReadOnly('true'));
+        $this->assertSame('true', $this->request->getCustomerReadOnly());
+    }
+
+    public function testCustomView()
+    {
+        $this->assertSame($this->request, $this->request->setCustomView('Bootstrap'));
+        $this->assertSame('Bootstrap', $this->request->getCustomView());
+    }
+
+    public function testVerifyCustomerPhone()
+    {
+        $this->assertSame($this->request, $this->request->setVerifyCustomerPhone('true'));
+        $this->assertSame('true', $this->request->getVerifyCustomerPhone());
+    }
+
+    public function testVerifyCustomerEmail()
+    {
+        $this->assertSame($this->request, $this->request->setVerifyCustomerEmail('true'));
+        $this->assertSame('true', $this->request->getVerifyCustomerEmail());
+    }
+
+}

--- a/tests/Mock/RapidSharedCreateCardRequestFailure.txt
+++ b/tests/Mock/RapidSharedCreateCardRequestFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Cache-control: no-cache="set-cookie"
+Content-Type: application/json; charset=utf-8
+Date: Thu, 27 Jun 2013 05:22:52 GMT
+Set-Cookie: AWSELB=8361C96B088FEBBC7D3ABDFE8BA0FF6501B9705E7D00F53B19AA8D0E66C1AD34691F2170CBA3CC4FEE8666E2FB3C85D3B0E238FA2E93B31AAC1C98DFF4D0639139359FE706;PATH=/;MAX-AGE=86400
+X-EWAY-VIA: api-au.sandbox.ewaypayments.com/
+X-EWAY-VIA-FROM: http://api.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-EWAY-VIA-HTTP-METHOD: POST
+X-EWAY-VIA-HTTP-STATUS: 200
+X-EWAY-VIA-TO: http://api-au.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-ID: AM-131
+X-Powered-By: eWAY
+X-Staging: AU
+Content-Length: 649
+Connection: keep-alive
+
+{"AccessCode":null,"Customer":{"TokenCustomerID":null,"Reference":null,"Title":null,"FirstName":null,"LastName":null,"CompanyName":null,"JobDescription":null,"Street1":null,"Street2":null,"City":null,"State":null,"PostalCode":null,"Country":null,"Email":null,"Phone":null,"Mobile":null,"Comments":null,"Fax":null,"Url":null,"CardNumber":null,"CardStartMonth":null,"CardStartYear":null,"CardIssueNumber":null,"CardName":null,"CardExpiryMonth":null,"CardExpiryYear":null,"IsActive":false},"Payment":{"TotalAmount":0,"InvoiceNumber":null,"InvoiceDescription":null,"InvoiceReference":null,"CurrencyCode":"AUD"},"FormActionURL":null,"Errors":"V6042,V6043,V6044"}

--- a/tests/Mock/RapidSharedCreateCardRequestSuccess.txt
+++ b/tests/Mock/RapidSharedCreateCardRequestSuccess.txt
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Cache-control: no-cache="set-cookie"
+Content-Type: application/json; charset=utf-8
+Date: Wed, 26 Jun 2013 13:11:50 GMT
+Set-Cookie: AWSELB=8361C96B088FEBBC7D3ABDFE8BA0FF6501B9705E7D00F53B19AA8D0E66C1AD34691F2170CB4C6B4D750DDAD028ED5C0787DEB1569F57CC58B5923AA0229EC5B49BD7647A57;PATH=/;MAX-AGE=86400
+X-EWAY-VIA: api-au.sandbox.ewaypayments.com/
+X-EWAY-VIA-FROM: http://api.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-EWAY-VIA-HTTP-METHOD: POST
+X-EWAY-VIA-HTTP-STATUS: 200
+X-EWAY-VIA-TO: http://api-au.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-ID: AM-143
+X-Powered-By: eWAY
+Content-Length: 1112
+Connection: keep-alive
+
+{"SharedPaymentUrl":"https://secure.ewaypayments.com/sharedpayment?AccessCode=F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","AccessCode":"F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","Customer":{"TokenCustomerID":"","Reference":"","Title":"","FirstName":"","LastName":"","CompanyName":"","JobDescription":"","Street1":"","Street2":"","City":"","State":"","PostalCode":"","Country":"","Email":"","Phone":"","Mobile":"","Comments":"","Fax":"","Url":"","CardNumber":"","CardStartMonth":"","CardStartYear":"","CardIssueNumber":"","CardName":"","CardExpiryMonth":"","CardExpiryYear":"","IsActive":false},"Payment":{"TotalAmount":0,"InvoiceNumber":null,"InvoiceDescription":null,"InvoiceReference":null,"CurrencyCode":"AUD"},"FormActionURL":"https://secure.ewaypayments.com/AccessCode/F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","Errors":null}

--- a/tests/Mock/RapidSharedUpdateCardRequestFailure.txt
+++ b/tests/Mock/RapidSharedUpdateCardRequestFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Cache-control: no-cache="set-cookie"
+Content-Type: application/json; charset=utf-8
+Date: Thu, 27 Jun 2013 05:22:52 GMT
+Set-Cookie: AWSELB=8361C96B088FEBBC7D3ABDFE8BA0FF6501B9705E7D00F53B19AA8D0E66C1AD34691F2170CBA3CC4FEE8666E2FB3C85D3B0E238FA2E93B31AAC1C98DFF4D0639139359FE706;PATH=/;MAX-AGE=86400
+X-EWAY-VIA: api-au.sandbox.ewaypayments.com/
+X-EWAY-VIA-FROM: http://api.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-EWAY-VIA-HTTP-METHOD: POST
+X-EWAY-VIA-HTTP-STATUS: 200
+X-EWAY-VIA-TO: http://api-au.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-ID: AM-131
+X-Powered-By: eWAY
+X-Staging: AU
+Content-Length: 649
+Connection: keep-alive
+
+{"AccessCode":null,"Customer":{"TokenCustomerID":null,"Reference":null,"Title":null,"FirstName":null,"LastName":null,"CompanyName":null,"JobDescription":null,"Street1":null,"Street2":null,"City":null,"State":null,"PostalCode":null,"Country":null,"Email":null,"Phone":null,"Mobile":null,"Comments":null,"Fax":null,"Url":null,"CardNumber":null,"CardStartMonth":null,"CardStartYear":null,"CardIssueNumber":null,"CardName":null,"CardExpiryMonth":null,"CardExpiryYear":null,"IsActive":false},"Payment":{"TotalAmount":0,"InvoiceNumber":null,"InvoiceDescription":null,"InvoiceReference":null,"CurrencyCode":"AUD"},"FormActionURL":null,"Errors":"V6040"}

--- a/tests/Mock/RapidSharedUpdateCardRequestSuccess.txt
+++ b/tests/Mock/RapidSharedUpdateCardRequestSuccess.txt
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Cache-control: no-cache="set-cookie"
+Content-Type: application/json; charset=utf-8
+Date: Wed, 26 Jun 2013 13:11:50 GMT
+Set-Cookie: AWSELB=8361C96B088FEBBC7D3ABDFE8BA0FF6501B9705E7D00F53B19AA8D0E66C1AD34691F2170CB4C6B4D750DDAD028ED5C0787DEB1569F57CC58B5923AA0229EC5B49BD7647A57;PATH=/;MAX-AGE=86400
+X-EWAY-VIA: api-au.sandbox.ewaypayments.com/
+X-EWAY-VIA-FROM: http://api.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-EWAY-VIA-HTTP-METHOD: POST
+X-EWAY-VIA-HTTP-STATUS: 200
+X-EWAY-VIA-TO: http://api-au.sandbox.ewaypayments.com/CreateAccessCodeShared.json
+X-ID: AM-143
+X-Powered-By: eWAY
+Content-Length: 1112
+Connection: keep-alive
+
+{"SharedPaymentUrl":"https://secure.ewaypayments.com/sharedpayment?AccessCode=F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","AccessCode":"F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","Customer":{"TokenCustomerID":"","Reference":"","Title":"","FirstName":"","LastName":"","CompanyName":"","JobDescription":"","Street1":"","Street2":"","City":"","State":"","PostalCode":"","Country":"","Email":"","Phone":"","Mobile":"","Comments":"","Fax":"","Url":"","CardNumber":"","CardStartMonth":"","CardStartYear":"","CardIssueNumber":"","CardName":"","CardExpiryMonth":"","CardExpiryYear":"","IsActive":false},"Payment":{"TotalAmount":0,"InvoiceNumber":null,"InvoiceDescription":null,"InvoiceReference":null,"CurrencyCode":"AUD"},"FormActionURL":"https://secure.ewaypayments.com/AccessCode/F9802j0-O7sdVLnOcb_3IPryTxHDtKY8u_0pb10GbYq-Xjvbc-5Bc_LhI-oBIrTxTCjhOFn7Mq-CwpkLDja5-iu-Dr3DjVTr9u4yxSB5BckdbJqSA4WWydzDO0jnPWfBdKcWL","Errors":null}

--- a/tests/RapidSharedGatewayTest.php
+++ b/tests/RapidSharedGatewayTest.php
@@ -28,4 +28,20 @@ class RapidSharedGatewayTest extends GatewayTestCase
         $this->assertInstanceOf('Omnipay\Eway\Message\RapidCompletePurchaseRequest', $request);
         $this->assertSame('10.00', $request->getAmount());
     }
+
+    public function testCreateCard()
+    {
+        $request = $this->gateway->createCard(array('amount' => '10.00'));
+
+        $this->assertInstanceOf('\Omnipay\Eway\Message\RapidSharedCreateCardRequest', $request);
+        $this->assertSame('10.00', $request->getAmount());
+    }
+
+    public function testUpdateCard()
+    {
+        $request = $this->gateway->updateCard(array('amount' => '10.00'));
+
+        $this->assertInstanceOf('\Omnipay\Eway\Message\RapidSharedUpdateCardRequest', $request);
+        $this->assertSame('10.00', $request->getAmount());
+    }
 }


### PR DESCRIPTION
Added Requests for both CreateCard and UpdateCard through RapidShared (roughly mimicking the functionality in RapidDirect). I have not added any response requests as you can utilise the `completePurchase()` method to finalise both of them all the same. Let me know if you would prefer these as separate responses.