### PR TITLE
Remove php 5.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
I've just pulled this out from #23 as it seems to be an easy merge & I thought it might simply things a little