### PR TITLE
Add auth to Rapid requests

### DIFF
--- a/src/Message/RapidCaptureRequest.php
+++ b/src/Message/RapidCaptureRequest.php
@@ -54,9 +54,12 @@ class RapidCaptureRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword()),
             'content-type' => 'application/json',
-        ], json_encode($data));
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }

--- a/src/Message/RapidDirectAbstractRequest.php
+++ b/src/Message/RapidDirectAbstractRequest.php
@@ -101,7 +101,11 @@ abstract class RapidDirectAbstractRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }

--- a/src/Message/RapidDirectCreateCardRequest.php
+++ b/src/Message/RapidDirectCreateCardRequest.php
@@ -76,7 +76,11 @@ class RapidDirectCreateCardRequest extends RapidDirectAbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         $this->response = new RapidDirectCreateCardResponse(
             $this,

--- a/src/Message/RapidDirectUpdateCardRequest.php
+++ b/src/Message/RapidDirectUpdateCardRequest.php
@@ -81,7 +81,11 @@ class RapidDirectUpdateCardRequest extends RapidDirectAbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidDirectCreateCardResponse(
             $this,

--- a/src/Message/RapidDirectVoidRequest.php
+++ b/src/Message/RapidDirectVoidRequest.php
@@ -24,9 +24,12 @@ class RapidDirectVoidRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword()),
             'content-type' => 'application/json',
-        ], json_encode($data));
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }

--- a/src/Message/RapidPurchaseRequest.php
+++ b/src/Message/RapidPurchaseRequest.php
@@ -39,7 +39,11 @@ class RapidPurchaseRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }

--- a/src/Message/RapidSharedPurchaseRequest.php
+++ b/src/Message/RapidSharedPurchaseRequest.php
@@ -49,7 +49,11 @@ class RapidSharedPurchaseRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RapidSharedResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }


### PR DESCRIPTION
During the v3 update authentication was removed from the requests, breaking the library. See issue #27 (this PR does not solve the fact an authentication failure doesn't return an error).