### PR TITLE
Handle encrypted credit card details where supplied #9

### DIFF
--- a/src/RapidDirectGateway.php
+++ b/src/RapidDirectGateway.php
@@ -135,6 +135,9 @@ class RapidDirectGateway extends AbstractGateway
      */
     public function purchase(array $parameters = [])
     {
+        if (is_array($parameters['card']) && isset($parameters['card']['number']) && substr($parameters['card']['number'], 0, 9) ===  'eCrypted:') {
+            $parameters['encryptedCardNumber'] = $parameters['card']['number'];
+        }
         return $this->createRequest('\Omnipay\Eway\Message\RapidDirectPurchaseRequest', $parameters);
     }
 
@@ -152,6 +155,9 @@ class RapidDirectGateway extends AbstractGateway
      */
     public function authorize(array $parameters = [])
     {
+        if (isset($parameters['card']['number']) && substr($parameters['card']['number'], 0, 9) ===  'eCrypted:') {
+            $parameters['encryptedCardNumber'] = $parameters['card']['number'];
+        }
         return $this->createRequest('\Omnipay\Eway\Message\RapidDirectAuthorizeRequest', $parameters);
     }
 


### PR DESCRIPTION
Eway already supports encryptedCardNumber as a paramter. However, that relies on the calling
code 'knowing' whether the card has been encrypted - which would not happen if a script blocker was
in play and is hard for the calling code to adapt to generically.

However, at this point in the code we know that if it is following the eway format for being encrypted
then it has been encrypted. I would note that it is supported by the Request object
not the credit card class but
a) that is already the case, this just makes it a bit simpler to use and
b) the encryptedCardNumber does not hold sensitive data in the same way that the 'card'
parameters do.

The upstream plan appears to be to have another class to handle this - in which case this bit of handling code
and the code that interacts with it could be updated later to reflect that