### PR TITLE
[Hotfix] Added headers to refunds

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -56,7 +56,11 @@ class RefundRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], json_encode($data));
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':' . $this->getPassword())
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, json_encode($data));
 
         return $this->response = new RefundResponse($this, json_decode((string) $httpResponse->getBody(), true));
     }


### PR DESCRIPTION
Looks like a recent update (https://github.com/thephpleague/omnipay-eway/commit/a32592a64b02fef99a2977bc2727f9e6859fe5ac#diff-0ada237d4b1b4579f4ea119db2a8b717L59) broke the refunds ability. 

This was due to the fact headers was set to an empty array. This hotfix resolves this.