### PR TITLE
Remove card details if TokenCustomerID is provided.

### DIFF
--- a/src/Message/RapidDirectPurchaseRequest.php
+++ b/src/Message/RapidDirectPurchaseRequest.php
@@ -93,7 +93,7 @@ class RapidDirectPurchaseRequest extends RapidDirectAbstractRequest
             $data['Method'] = 'ProcessPayment';
         }
 
-        if(isset($data['Customer']['TokenCustomerID'])) {
+        if (isset($data['Customer']['TokenCustomerID'])) {
             // If we are paying using token, remove the card details otherwise the displayed data will be overwritten on eWay dashboard
             unset($data['Customer']['CardDetails']);
         }

--- a/src/Message/RapidDirectPurchaseRequest.php
+++ b/src/Message/RapidDirectPurchaseRequest.php
@@ -94,7 +94,8 @@ class RapidDirectPurchaseRequest extends RapidDirectAbstractRequest
         }
 
         if (isset($data['Customer']['TokenCustomerID'])) {
-            // If we are paying using token, remove the card details otherwise the displayed data will be overwritten on eWay dashboard
+            // If we are paying using token, remove the card details
+            // otherwise the displayed data will be overwritten on eWay dashboard
             unset($data['Customer']['CardDetails']);
         }
 

--- a/src/Message/RapidDirectPurchaseRequest.php
+++ b/src/Message/RapidDirectPurchaseRequest.php
@@ -93,6 +93,11 @@ class RapidDirectPurchaseRequest extends RapidDirectAbstractRequest
             $data['Method'] = 'ProcessPayment';
         }
 
+        if(isset($data['Customer']['TokenCustomerID'])) {
+            // If we are paying using token, remove the card details otherwise the displayed data will be overwritten on eWay dashboard
+            unset($data['Customer']['CardDetails']);
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
Recent eWay update caused the dashboard to use credit card data that is given in the payload instead of using data from token.

By removing card details from the payload and using just TokenCustomerID, we will preserve the correct data from the token.

If we are only paying using token, normally we do not have expiry month and year.
omnipay-eway automatically generate the month & year to be 12/99 which causes confusion on eWay dashboard.